### PR TITLE
Resetting state pollution in `global_um`

### DIFF
--- a/test/test_utter_more.py
+++ b/test/test_utter_more.py
@@ -67,6 +67,8 @@ def test_ibu_aut(global_um):
     global_um.add_utterance_template(OR_CURLY)
     global_um.iter_build_utterances()
     assert global_um.utterances == [DC_ANS, SC_ANS, OC_ANS]
+    global_um.utterance_templates.clear()
+    global_um.utterances.clear()
 
 
 @pytest.mark.parametrize('fname, saved_as, written_as', [


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_ibu_aut` by resetting state pollution in `global_um` by calling method clear()

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 test/test_utter_more.py::test_ibu_aut`:

```
        global_um.iter_build_utterances()
>       assert global_um.utterances == [DC_ANS, SC_ANS, OC_ANS]
E       AssertionError: assert [['{beginning...d', ...], ...] == [['{beginning...inmidd', ...]]
E         Left contains 6 more items, first extra item: ['{beginning}{middle}{end}', '{beginning}{middle}', '{beginning}{end}', '{beginning}', '{middle}{end}', '{middle}', ...]
E         Use -v to get the full diff
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
